### PR TITLE
Update Travis CI link

### DIFF
--- a/DiscImageChef.Server/docs/README.md
+++ b/DiscImageChef.Server/docs/README.md
@@ -5,7 +5,7 @@ Disc Image Chef (because "swiss-army-knife" is used too much)
 Copyright © 2011-2018 Natalia Portillo <claunia@claunia.com>
 
 [![Build status](https://dev.azure.com/DiscImageChef/DiscImageChef/_apis/build/status/DiscImageChef-.NET%20Desktop-CI)](https://dev.azure.com/DiscImageChef/DiscImageChef/_build/latest?definitionId=4)
-[![Build Status](https://travis-ci.org/claunia/DiscImageChef.svg?branch=master)](https://travis-ci.org/claunia/DiscImageChef)
+[![Build Status](https://travis-ci.org/discimagechef/DiscImageChef.svg?branch=master)](https://travis-ci.org/discimagechef/DiscImageChef)
 [![Build status](https://ci.appveyor.com/api/projects/status/vim4c8h028pn5oys?svg=true)](https://ci.appveyor.com/project/claunia/discimagechef)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fclaunia%2FDiscImageChef.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fclaunia%2FDiscImageChef?ref=badge_shield)
 


### PR DESCRIPTION
It was pointed to the old claunia/DiscImageChef link, not the discimagechef/DiscImageChef one.